### PR TITLE
Preserve attempted page after login

### DIFF
--- a/includes/auth.php
+++ b/includes/auth.php
@@ -1,8 +1,11 @@
 <?php
 session_start();
 
+// If the user is not logged in, redirect to the sign-in page and include the
+// originally requested URL so they can be sent back after a successful login.
 if (!isset($_SESSION['user_id'])) {
-    header("Location: signin.php"); // Redirect to login if not logged in
+    $redirect = urlencode($_SERVER['REQUEST_URI'] ?? 'index.php');
+    header("Location: signin.php?redirect=$redirect");
     exit();
 }
 ?>

--- a/login.php
+++ b/login.php
@@ -21,8 +21,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $_SESSION['role'] = $user['role'];
             $_SESSION['name'] = $user['name'];
 
-            // Redirect to index.php (common dashboard)
-            header("Location: index.php");
+            // Redirect to the originally requested page, or fall back to the dashboard
+            $redirect = !empty($_POST['redirect']) ? $_POST['redirect'] : 'index.php';
+            header("Location: $redirect");
             exit;
         } else {
             echo "❌ Invalid password!";

--- a/signin.php
+++ b/signin.php
@@ -1,3 +1,4 @@
+<?php $redirect = $_GET['redirect'] ?? ''; ?>
 <!DOCTYPE html>
 <html lang="en">
 
@@ -207,6 +208,7 @@
 
                         <!-- Login Form -->
                         <form class="login-form" action="login.php" method="POST">
+                            <input type="hidden" name="redirect" value="<?php echo htmlspecialchars($redirect); ?>">
                             <div class="mb-3 form-group">
                                 <label>Email Address</label>
                                 <input type="email" class="form-control" name="email" placeholder="partner@example.com" required>


### PR DESCRIPTION
## Summary
- Redirect unauthenticated users to the login page with their originally requested URL
- Carry the redirect target through the sign-in form
- Return users to their intended page after successful authentication

## Testing
- `php -l includes/auth.php`
- `php -l login.php`
- `php -l signin.php`
- `npm test` *(fails: no package.json)*
- `composer test` *(fails: command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68accca971608324a4c8fcbecf8bbf9a